### PR TITLE
Fix OpenNI include path when compile sensor-kinect (and sensor).

### DIFF
--- a/sensor-kinect.rb
+++ b/sensor-kinect.rb
@@ -40,8 +40,8 @@ class SensorKinect < Formula
     cd 'Platform/Linux'
 
     # Fix build files
-    inreplace 'Build/EngineLibMakefile', '/usr/include/ni', '/usr/local/include/ni'
-    inreplace 'Build/Utils/EngineUtilMakefile', '/usr/include/ni', '/usr/local/include/ni'
+    inreplace 'Build/EngineLibMakefile', '/usr/include/ni', "#{HOMEBREW_PREFIX}/include/ni"
+    inreplace 'Build/Utils/EngineUtilMakefile', '/usr/include/ni', "#{HOMEBREW_PREFIX}/include/ni"
     inreplace 'CreateRedist/RedistMaker', 'echo $((N_CORES*2))', 'echo $((N_CORES))'
 
     # Build SensorKinect

--- a/sensor.rb
+++ b/sensor.rb
@@ -40,8 +40,8 @@ class Sensor < Formula
     cd 'Platform/Linux'
 
     # Fix build files
-    inreplace 'Build/EngineLibMakefile', '/usr/include/ni', '/usr/local/include/ni'
-    inreplace 'Build/Utils/EngineUtilMakefile', '/usr/include/ni', '/usr/local/include/ni'
+    inreplace 'Build/EngineLibMakefile', '/usr/include/ni', "#{HOMEBREW_PREFIX}/include/ni"
+    inreplace 'Build/Utils/EngineUtilMakefile', '/usr/include/ni', "#{HOMEBREW_PREFIX}/include/ni"
     inreplace 'CreateRedist/RedistMaker', 'echo $((N_CORES*2))', 'echo $((N_CORES))'
 
     # Build Sensor


### PR DESCRIPTION
`brew install sensor-kinect` failed when HOMEBREW_PREFIX is not '/usr/local'.
