### PR TITLE
Fix Class-Path of OpenNI.jar and com.primesense.NITE.jar

### DIFF
--- a/nite.rb
+++ b/nite.rb
@@ -37,6 +37,9 @@ class Nite < Formula
 
     ohai 'Installing...'
 
+    inreplace 'Samples/Boxes.java/Manifest.txt', '/usr/share/java', "#{share}/java"
+    inreplace 'Samples/Build/Common/CommonJavaMakefile', '/usr/share/java', "#{share}/java"
+
     # Install libs
     lib.install Dir['Bin/libXnVNite*.dylib']
     lib.install Dir['Bin/libXnVCNITE*.dylib']

--- a/openni.rb
+++ b/openni.rb
@@ -42,6 +42,7 @@ class Openni < Formula
 
     # Fix build files
     inreplace 'Source/OpenNI/XnOpenNI.cpp', '/var/lib/ni/', "#{var}/lib/ni/"
+    inreplace 'Platform/Linux/Build/Common/CommonJavaMakefile', '/usr/share/java', "#{share}/java"
 
     # Build OpenNI
     cd 'Platform/Linux/CreateRedist'

--- a/sensor-kinect.rb
+++ b/sensor-kinect.rb
@@ -42,6 +42,7 @@ class SensorKinect < Formula
     inreplace 'Platform/Linux/Build/EngineLibMakefile', '/usr/include/ni', "#{HOMEBREW_PREFIX}/include/ni"
     inreplace 'Platform/Linux/Build/Utils/EngineUtilMakefile', '/usr/include/ni', "#{HOMEBREW_PREFIX}/include/ni"
     inreplace 'Platform/Linux/CreateRedist/RedistMaker', 'echo $((N_CORES*2))', 'echo $((2))'
+    inreplace 'Platform/Linux/Build/Common/CommonJavaMakefile', '/usr/share/java', "#{share}/java"
 
     # Build SensorKinect
     cd 'Platform/Linux/CreateRedist'

--- a/sensor.rb
+++ b/sensor.rb
@@ -42,6 +42,7 @@ class Sensor < Formula
     inreplace 'Platform/Linux/Build/EngineLibMakefile', '/usr/include/ni', "#{HOMEBREW_PREFIX}/include/ni"
     inreplace 'Platform/Linux/Build/Utils/EngineUtilMakefile', '/usr/include/ni', "#{HOMEBREW_PREFIX}/include/ni"
     inreplace 'Platform/Linux/CreateRedist/RedistMaker', 'echo $((N_CORES*2))', 'echo $((2))'
+    inreplace 'Platform/Linux/Build/Common/CommonJavaMakefile', '/usr/share/java', "#{share}/java"
 
     # Build Sensor
     cd 'Platform/Linux/CreateRedist'


### PR DESCRIPTION
openni.rb 及び nite.rb で .jar ファイルの置き場所を

``` ruby
"#{share}/java"
```

にしているため、修正前だと下記のようなエラーが発生する

```
$ java -Djava.library.path=`brew --prefix`/lib -jar org.OpenNI.Samples.UserTracker.jar
Exception in thread "main" java.lang.NoClassDefFoundError: org/OpenNI/GeneralException
      at org.OpenNI.Samples.UserTracker.UserTrackerApplication.main(UserTrackerApplication.java:67)
Caused by: java.lang.ClassNotFoundException: org.OpenNI.GeneralException
       at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
       at java.security.AccessController.doPrivileged(Native Method)
       at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
       at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
       at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:301)
       at java.lang.ClassLoader.loadClass(ClassLoader.java:247)
```

NITE の `Sample/Bin/x64-Relase/com.primesense.NITE.Samples.Boxes.jar` は
tar.bz2 の時点で既に作成済みなので Class-Path を変えられず。
jar 展開 → MANIFEST.MF で inreplace → jar 生成しなおす、でもいいけど。
